### PR TITLE
Added 50th and 99th percentile response times to the result summary

### DIFF
--- a/result.go
+++ b/result.go
@@ -92,7 +92,9 @@ func PrintSummary(r RunReport) {
 		log.Println("  errors:", v.Requests-v.success)
 		log.Println("     rps:", v.Rate)
 		log.Println("    mean:", v.Latencies.Mean)
+		log.Println("    50th:", v.Latencies.P50)
 		log.Println("    95th:", v.Latencies.P95)
+		log.Println("    99th:", v.Latencies.P99)
 		log.Println("     max:", v.Latencies.Max)
 		log.Println(" success:", v.successLogEntry(), "%")
 	}


### PR DESCRIPTION
For a complete overview of the test it's nice to have the 50th and 99th percentiles included in the summary. Otherwise it's necessary to count the nano seconds from the report, which is a bit inconvenient. 